### PR TITLE
Settings subcommand

### DIFF
--- a/src/ansible_navigator/actions/settings.py
+++ b/src/ansible_navigator/actions/settings.py
@@ -1,0 +1,42 @@
+""" :settings
+"""
+from . import _actions as actions
+from ..app import App
+from ..app_public import AppPublic
+from ..ui_framework import Interaction
+
+
+@actions.register
+class Action(App):
+    """handle :settings"""
+
+    # pylint: disable=too-few-public-methods
+
+    KEGEX = r"^se(?:ttings)?$"
+
+    def __init__(self, args):
+        super().__init__(args=args, logger_name=__name__, name="settings")
+
+    # pylint: disable=unused-argument
+    def run(self, interaction: Interaction, app: AppPublic) -> Interaction:
+        """Handle settings interactive
+
+        :param interaction: The interaction from the user
+        :param app: The app instance
+        """
+        self._logger.debug("settings requested")
+        self._prepare_to_run(app, interaction)
+
+        while True:
+            self._calling_app.update()
+            next_interaction: Interaction = interaction.ui.show(["settings called"])
+            if next_interaction.name != "refresh":
+                break
+
+        self._prepare_to_exit(interaction)
+        return next_interaction
+
+    def run_stdout(self) -> int:
+        """Handle :settings stdout"""
+        print("settings called")
+        return 0

--- a/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
+++ b/src/ansible_navigator/configuration_subsystem/navigator_configuration.py
@@ -141,6 +141,10 @@ navigator_subcommds = [
             " 'ansible-navigator run --help-playbook --mode stdout'"
         ),
     ),
+    SubCommand(
+        name="settings",
+        description="Review the current ansible-navigator settings",
+    ),
     SubCommand(name="welcome", description="Start at the welcome page"),
 ]
 


### PR DESCRIPTION
This adds the `:settings` subcommand and support for `ansible-navigator settings`

The `run` function in the action is called for the TUI, and the `run_stdout` function when `mode` is set to `stdout`

The `KEGEX` is the regex to match at the colon prompt, so you could either `:settings` or just `:se`

This can be tested:

```
ansible-navigator  #then :settings or :se
 ansible-navigator settings
 ansible-navigator settings --mode stdout
```

`settings` will also now show in the `--help`