### PR TITLE
working on stdout test, WIP

### DIFF
--- a/tests/fixtures/integration/actions/settings/test_stdout_tmux.py/test/0.json
+++ b/tests/fixtures/integration/actions/settings/test_stdout_tmux.py/test/0.json
@@ -1,0 +1,38 @@
+{
+    "name": "test[print settings to stdout  clear && ansible-navigator settings settings --ee True --ll debug --mode stdout]",
+    "index": 0,
+    "comment": "print settings to stdout",
+    "additional_information": {
+        "look_fors": [
+            "name: set_environment_variable"
+        ],
+        "look_nots": [],
+        "compared_fixture": false
+    },
+    "output": [
+        "  name: set_environment_variable",
+        "  settings_file_sample:",
+        "    ansible-navigator:",
+        "      execution-environment:",
+        "        environment-variables:",
+        "          set: <------",
+        "  source: Value has not been set",
+        "- choices: []",
+        "  cli_parameters:",
+        "    long: --workdir",
+        "    short: --bwd",
+        "  current_settings_file: None",
+        "  current_value: /home/user/ansible/ansible-navigator",
+        "  default: 'True'",
+        "  default_value: /home/user/ansible/ansible-navigator",
+        "  description: Specify the path that contains ansible-builder manifest files",
+        "  env_var: ANSIBLE_NAVIGATOR_WORKDIR",
+        "  name: workdir",
+        "  settings_file_sample:",
+        "    ansible-navigator:",
+        "      ansible-builder:",
+        "        workdir: <------",
+        "  source: Defaults",
+        "(virtenvs) bash-5.1$"
+    ]
+}

--- a/tests/integration/actions/settings/base.py
+++ b/tests/integration/actions/settings/base.py
@@ -76,7 +76,7 @@ class BaseClass:
             search_within_response=search_within_response,
         )
         if step.mask:
-            # mask out some settings that is subject to change each run, app changes if called from CLI
+            # mask out some settings that is subject to change each run
             maskables = [
                 "app",
                 "current_settings_file",

--- a/tests/integration/actions/settings/test_stdout_tmux.py
+++ b/tests/integration/actions/settings/test_stdout_tmux.py
@@ -1,0 +1,75 @@
+"""Tests for ``settings`` from CLI, stdout."""
+import pytest
+
+from ..._interactions import Command
+from ..._interactions import SearchFor
+from ..._interactions import Step
+from ..._interactions import add_indices
+from .base import BaseClass
+
+
+class StdoutCommand(Command):
+    """stdout command"""
+
+    subcommand = "settings"
+    preclear = True
+
+
+class ShellCommand(Step):
+    """a shell command"""
+
+    search_within_response = SearchFor.PROMPT
+
+
+stdout_tests = (
+    ShellCommand(
+        comment="print settings to stdout with ee",
+        user_input=StdoutCommand(
+            cmdline="settings",
+            mode="stdout",
+            execution_environment=True,
+        ).join(),
+        look_fors=["name: set_environment_variable"],
+    ),
+    ShellCommand(
+        comment="print settings to stdout with no ee",
+        user_input=StdoutCommand(
+            cmdline="settings",
+            mode="stdout",
+            execution_environment=False,
+        ).join(),
+        look_fors=["name: set_environment_variable"],
+    ),
+    ShellCommand(  # needs work
+        comment="print settings to stdout with no ee",
+        user_input=StdoutCommand(
+            cmdline="settings",
+            mode="interactive",
+            execution_environment=True,
+        ).join(),
+        look_fors=["name: set_environment_variable"],
+    ),
+    ShellCommand(  # needs work
+        comment="print settings to stdout with no ee",
+        user_input=StdoutCommand(
+            cmdline="settings",
+            mode="interactive",
+            execution_environment=False,
+        ).join(),
+        look_fors=["name: set_environment_variable"],
+    ),
+)
+
+steps = add_indices(stdout_tests)
+
+
+def step_id(value):
+    """return the test id from the test step object"""
+    return f"{value.comment}  {value.user_input}"
+
+
+@pytest.mark.parametrize("step", steps, ids=step_id)
+class Test(BaseClass):
+    """Run the tests for ``config`` from CLI, mode stdout."""
+
+    UPDATE_FIXTURES = True

--- a/tests/integration/actions/settings/test_stdout_tmux.py
+++ b/tests/integration/actions/settings/test_stdout_tmux.py
@@ -70,6 +70,6 @@ def step_id(value):
 
 @pytest.mark.parametrize("step", steps, ids=step_id)
 class Test(BaseClass):
-    """Run the tests for ``config`` from CLI, mode stdout."""
+    """Run the tests for ``settings`` from CLI, mode stdout."""
 
     UPDATE_FIXTURES = True


### PR DESCRIPTION
sending this just in case you have the time or want to look tonight/evening, I will be taking another stab tonight, just to see at least what needs to change or stay the same with the `--help` flag for settings. currently mode does not matter on CLI if you run `ansible-navigator]$ ansible-navigator settings --help`. It will return the same, no matter which mode is selected. 